### PR TITLE
Fix: Move packages out of devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,4 +46,3 @@
     "LRUCache.js",
     "LRUCache.d.ts"
   ]
-}

--- a/package.json
+++ b/package.json
@@ -25,12 +25,14 @@
     "build": "tsc -p ./tsconfig.json",
     "deploy": "npm version patch; npm run build; npm publish"
   },
-  "devDependencies": {
-    "@types/react": "^16.9.31",
-    "typescript": "^3.8.3",
+  "dependencies": {
     "superellipsejs": "^0.0.6",
     "react-use-measure": "^2.0.0",
     "resize-observer-polyfill": "^1.5.1"
+  },
+  "devDependencies": {
+    "@types/react": "^16.9.31",
+    "typescript": "^3.8.3",
   },
   "peerDependencies": {
     "react": ">=16.11",


### PR DESCRIPTION
This change moves 3 necessary dependencies from "devDependencies" to "dependencies" to fix the issue of the package not working on install.